### PR TITLE
Fix bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ end
 
 group :development, :test do
   gem 'pry'
-  gem 'pry-debugger'
+  gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'rspec-mocks'
 end


### PR DESCRIPTION
Changing pry-debugger to pry-byebug as Ruby 2.x is not supported